### PR TITLE
Remove unnecessary definite article from lingering and splash potion

### DIFF
--- a/common/src/main/resources/assets/untitledduckmod/lang/en_us.json
+++ b/common/src/main/resources/assets/untitledduckmod/lang/en_us.json
@@ -32,6 +32,6 @@
 
   "effect.untitledduckmod.intimidation": "Intimidation",
   "item.minecraft.potion.effect.intimidation": "Potion of Intimidation",
-  "item.minecraft.lingering_potion.effect.intimidation": "Lingering Potion of the Intimidation",
-  "item.minecraft.splash_potion.effect.intimidation": "Splash Potion of the Intimidation"
+  "item.minecraft.lingering_potion.effect.intimidation": "Lingering Potion of Intimidation",
+  "item.minecraft.splash_potion.effect.intimidation": "Splash Potion of Intimidation"
 }


### PR DESCRIPTION
Hi,
while doing the german translation I noticed that the Lingering and Splash Potion of Intimidation had a unnecessary "the". I removed it in order to match with the other vanilla potion names (e.g. "Splash Potion of Weakness").